### PR TITLE
fix: change link to conda env file in readme to correct path

### DIFF
--- a/README.md
+++ b/README.md
@@ -91,7 +91,7 @@ We tightly integrate three separate modules in the original latent diffusion mod
 
 ## Getting Started
 **Environment Setup**
-- We provide a [conda env file](environment.yml) that contains all the required dependencies.
+- We provide a [conda env file](environment.yaml) that contains all the required dependencies.
     ```
     conda env create -f environment.yaml
     ```


### PR DESCRIPTION
Clicking on the link to the conda env file in the README gives a 404. Just a small fix to correct the path.